### PR TITLE
Fix crash when max level

### DIFF
--- a/src/main/java/daripher/skilltree/SkillTreeMod.java
+++ b/src/main/java/daripher/skilltree/SkillTreeMod.java
@@ -11,13 +11,10 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(SkillTreeMod.MOD_ID)
 public class SkillTreeMod {
 	public static final String MOD_ID = "skilltree";
-	public static final Logger logger = LogManager.getLogger(MOD_ID);
 
 	public SkillTreeMod() {
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/daripher/skilltree/SkillTreeMod.java
+++ b/src/main/java/daripher/skilltree/SkillTreeMod.java
@@ -11,10 +11,13 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Mod(SkillTreeMod.MOD_ID)
 public class SkillTreeMod {
 	public static final String MOD_ID = "skilltree";
+	public static final Logger logger = LogManager.getLogger(MOD_ID);
 
 	public SkillTreeMod() {
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/daripher/skilltree/config/Config.java
+++ b/src/main/java/daripher/skilltree/config/Config.java
@@ -3,8 +3,6 @@ package daripher.skilltree.config;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import daripher.skilltree.SkillTreeMod;
@@ -13,7 +11,6 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.config.ModConfigEvent;

--- a/src/main/java/daripher/skilltree/config/Config.java
+++ b/src/main/java/daripher/skilltree/config/Config.java
@@ -3,6 +3,8 @@ package daripher.skilltree.config;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import daripher.skilltree.SkillTreeMod;
@@ -11,6 +13,7 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.Logging;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
@@ -184,7 +187,7 @@ public class Config {
 	public static int getSkillPointCost(int level) {
 		if (USE_POINTS_COSTS_ARRAY.get()) {
 			List<? extends Integer> costs = LEVEL_UP_COSTS.get();
-			if (level > costs.size()) {
+			if (level >= costs.size()) {
 				return costs.get(costs.size() - 1);
 			}
 			return costs.get(level);


### PR DESCRIPTION
Hi,

I had this crash when I was modifying the max level and reaching the lvl. 150. I figured out that the bug was caused by the following if statement. Now it should be fixed. It's the case on my version, allowing to buy skill point up to 1000 the limit allowed by the mod without crashing.

I paste here the crash I've got before fork this mod (I was running the 1.20.1 version) :
```
java.lang.IndexOutOfBoundsException: Index 150 out of bounds for length 150
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?] {}
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?] {}
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?] {}
	at java.util.Objects.checkIndex(Objects.java:361) ~[?:?] {re:mixin}
	at java.util.ArrayList.get(ArrayList.java:427) ~[?:?] {re:mixin}
	at daripher.skilltree.config.Config.getSkillPointCost(Config.java:190) ~[PassiveSkillTree-1.20.1-BETA-0.5.8.jar%23681!/:0.5.8] {re:classloading,pl:eventbus:A}
	at daripher.skilltree.client.screen.SkillTreeScreen.updateBuyPointButton(SkillTreeScreen.java:453) ~[PassiveSkillTree-1.20.1-BETA-0.5.8.jar%23681!/:0.5.8] {re:classloading}
	at daripher.skilltree.client.screen.SkillTreeScreen.updateScreen(SkillTreeScreen.java:440) ~[PassiveSkillTree-1.20.1-BETA-0.5.8.jar%23681!/:0.5.8] {re:classloading}
	at daripher.skilltree.client.screen.SkillTreeScreen.m_88315_(SkillTreeScreen.java:145) ~[PassiveSkillTree-1.20.1-BETA-0.5.8.jar%23681!/:0.5.8] {re:classloading}
	at net.minecraft.client.gui.screens.Screen.m_280264_(Screen.java:109) ~[client-1.20.1-20230612.114412-srg.jar%23786!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:ScreenAccessor,pl:mixin:APP:yungsmenutweaks.mixins.json:ScreenMixin,pl:mixin:APP:cumulus_menus.mixins.json:client.accessor.ScreenAccessor,pl:mixin:APP:kiwi.mixins.json:client.ScreenMixin,pl:mixin:APP:aether.mixins.json:client.accessor.ScreenAccessor,pl:mixin:APP:controlling.mixins.json:AccessScreen,pl:mixin:APP:konkrete.mixin.json:IMixinScreen,pl:mixin:APP:patchouli_xplat.mixins.json:client.AccessorScreen,pl:mixin:APP:vivecraft.mixins.json:client.gui.screens.ScreenMixin,pl:mixin:APP:vivecraft.mixins.json:client_vr.gui.screens.ScreenVRMixin,pl:mixin:APP:vivecraft.dynamicfps.mixins.json:DynamicFPSScreenVRMixin,pl:mixin:APP:fancymenu.general.mixin.json:IMixinScreen,pl:mixin:APP:fancymenu.general.mixin.json:MixinScreen,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraftforge.client.ForgeHooksClient.drawScreenInternal(ForgeHooksClient.java:427) ~[forge-1.20.1-47.2.1-universal.jar%23791!/:?] {re:mixin,re:classloading,pl:mixin:A}
	at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:420) ~[forge-1.20.1-47.2.1-universal.jar%23791!/:?] {re:mixin,re:classloading,pl:mixin:A}
	at net.minecraft.client.renderer.GameRenderer.m_109093_(GameRenderer.java:965) ~[client-1.20.1-20230612.114412-srg.jar%23786!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:apoli.mixins.json:GameRendererMixin,pl:mixin:APP:supplementaries-common.mixins.json:GameRendererMixin,pl:mixin:APP:rubidium.mixins.json:features.gui.hooks.console.GameRendererMixin,pl:mixin:APP:mixins.oculus.json:GameRendererAccessor,pl:mixin:APP:mixins.oculus.json:MixinGameRenderer,pl:mixin:APP:mixins.oculus.json:MixinModelViewBobbing,pl:mixin:APP:mixins.oculus.json:MixinTweakFarPlane,pl:mixin:APP:pehkui.mixins.json:client.compat115plus.GameRendererMixin,pl:mixin:APP:pehkui.mixins.json:client.compat1193plus.GameRendererMixin,pl:mixin:APP:ars_nouveau.mixins.json:GameRendererMixin,pl:mixin:APP:forge-immediatelyfast-common.mixins.json:core.compat.MixinGameRenderer,pl:mixin:APP:sodium-extra.mixins.json:prevent_shaders.MixinGameRenderer,pl:mixin:APP:controllable.common.mixins.json:client.GameRendererMixin,pl:mixin:APP:controllable.mixins.json:client.ForgeGameRendererMixin,pl:mixin:APP:vivecraft.mixins.json:client_vr.renderer.GameRendererVRMixin,pl:mixin:APP:vivecraft.optifine.mixins.json:OptifineGamerRendererVRMixin,pl:mixin:APP:vivecraft.forge.mixins.json:ForgeGameRendererVRMixin,pl:mixin:APP:alexscaves.mixins.json:client.GameRendererMixin,pl:mixin:APP:mixins.oculus.json:MixinGameRenderer_NightVisionCompat,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1146) ~[client-1.20.1-20230612.114412-srg.jar%23786!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:718) ~[client-1.20.1-20230612.114412-srg.jar%23786!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:218) ~[forge-47.2.1.jar:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:vivecraft.mixins.json:client.main.MainMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?] {}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?] {}
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?] {}
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?] {re:mixin}
	at net.minecraftforge.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:111) ~[fmlloader-1.20.1-47.2.1.jar:?] {}
	at net.minecraftforge.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:99) ~[fmlloader-1.20.1-47.2.1.jar:?] {}
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$makeService$0(CommonClientLaunchHandler.java:25) ~[fmlloader-1.20.1-47.2.1.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:108) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:78) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) ~[modlauncher-10.0.9.jar:?] {}
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:141) ~[bootstraplauncher-1.1.2.jar:?] {}
```