### PR TITLE
Add Weapon / Tool Compatibility Through Tags

### DIFF
--- a/src/generated/resources/.cache/ac82fa81ecb87290ed4da89250d9328159ba79a7
+++ b/src/generated/resources/.cache/ac82fa81ecb87290ed4da89250d9328159ba79a7
@@ -1,7 +1,10 @@
-// 1.20.1	2024-02-12T07:14:04.6511079	Tags for minecraft:item mod id skilltree
+// 1.20.1	2024-03-05T11:03:46.433311	Tags for minecraft:item mod id skilltree
 912807fae1f5d4fb0cd2645e952105207b245f35 data/curios/tags/items/necklace.json
 b0448e1e3142f31d11b1998a19dca53dfcab0a31 data/curios/tags/items/quiver.json
 66bb644ad4f941567a9624ab40ffcf18a197606b data/curios/tags/items/ring.json
 f9fb803cf86084b22047f5e6424e656d385660a2 data/forge/tags/items/curios/jewelry.json
 e3a08329a8faa4e76467f3cc10cb6daa98b57c64 data/forge/tags/items/nuggets/copper.json
+2325d584d37caa7fa0df5146c3cb3f9b3994bc38 data/forge/tags/items/tools.json
+4e278d6316375b25562152478e972abf60621094 data/forge/tags/items/tools/diggers.json
+01d06e1c3cd6ee881097875b179c1f9f014e3457 data/forge/tags/items/tools/melee_weapons.json
 6478354481ddac4828aa398c5c2bde4b997511f3 data/skilltree/tags/items/gems.json

--- a/src/generated/resources/data/forge/tags/items/tools.json
+++ b/src/generated/resources/data/forge/tags/items/tools.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#forge:tools/melee_weapons",
+    "#forge:tools/diggers"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/diggers.json
+++ b/src/generated/resources/data/forge/tags/items/tools/diggers.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "#minecraft:axes",
+    "#minecraft:hoes",
+    "#minecraft:pickaxes",
+    "#minecraft:shovels",
+    {
+      "id": "#forge:tools/knives",
+      "required": false
+    }
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/melee_weapons.json
+++ b/src/generated/resources/data/forge/tags/items/tools/melee_weapons.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "#minecraft:swords",
+    "#minecraft:axes",
+    "#forge:tools/tridents"
+  ]
+}

--- a/src/main/java/daripher/skilltree/data/generation/PSTItemTagsProvider.java
+++ b/src/main/java/daripher/skilltree/data/generation/PSTItemTagsProvider.java
@@ -11,8 +11,11 @@ import java.util.concurrent.CompletableFuture;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.tags.ItemTagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.BlockTagsProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -41,6 +44,10 @@ public class PSTItemTagsProvider extends ItemTagsProvider {
     add(PSTTags.QUIVERS, QuiverItem.class);
     add(PSTTags.NUGGETS_COPPER, PSTItems.COPPER_NUGGET.get());
     tag(PSTTags.JEWELRY).addTags(PSTTags.RINGS, PSTTags.NECKLACES);
+    tag(Tags.Items.TOOLS).addTags(PSTTags.TOOLS_MELEE_WEAPONS, PSTTags.TOOLS_DIGGERS);
+    tag(PSTTags.TOOLS_MELEE_WEAPONS).addTags(ItemTags.SWORDS, ItemTags.AXES, Tags.Items.TOOLS_TRIDENTS);
+	tag(PSTTags.TOOLS_DIGGERS).addTags(ItemTags.AXES, ItemTags.HOES, ItemTags.PICKAXES, ItemTags.SHOVELS)
+			.addOptionalTag(new ResourceLocation("forge", "tools/knives"));
   }
 
   private void add(TagKey<Item> itemTag, Class<? extends Item> itemClass) {

--- a/src/main/java/daripher/skilltree/init/PSTTags.java
+++ b/src/main/java/daripher/skilltree/init/PSTTags.java
@@ -18,4 +18,9 @@ public class PSTTags {
       ItemTags.create(new ResourceLocation("forge", "curios/jewelry"));
   public static final TagKey<Item> NUGGETS_COPPER =
       ItemTags.create(new ResourceLocation("forge", "nuggets/copper"));
+  public static final TagKey<Item> TOOLS_MELEE_WEAPONS =
+          ItemTags.create(new ResourceLocation("forge", "tools/melee_weapons"));
+  public static final TagKey<Item> TOOLS_DIGGERS =
+          ItemTags.create(new ResourceLocation("forge", "tools/diggers"));
+
 }

--- a/src/main/java/daripher/skilltree/skill/bonus/condition/item/EquipmentCondition.java
+++ b/src/main/java/daripher/skilltree/skill/bonus/condition/item/EquipmentCondition.java
@@ -7,6 +7,8 @@ import daripher.skilltree.client.tooltip.TooltipHelper;
 import daripher.skilltree.init.PSTItemConditions;
 import java.util.Objects;
 import java.util.function.Consumer;
+
+import daripher.skilltree.init.PSTTags;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -59,7 +61,7 @@ public class EquipmentCondition implements ItemCondition {
   }
 
   public static boolean isMeleeWeapon(ItemStack stack) {
-    return isSword(stack) || isAxe(stack) || isTrident(stack);
+    return isSword(stack) || isAxe(stack) || isTrident(stack) || stack.is(PSTTags.TOOLS_MELEE_WEAPONS);
   }
 
   public static boolean isLeggings(ItemStack stack) {
@@ -117,7 +119,7 @@ public class EquipmentCondition implements ItemCondition {
   }
 
   public static boolean isTool(ItemStack stack) {
-    return stack.getItem() instanceof DiggerItem;
+    return stack.getItem() instanceof DiggerItem || stack.is(PSTTags.TOOLS_DIGGERS);
   }
 
   public static boolean isHoe(ItemStack stack) {


### PR DESCRIPTION
This PR introduces `forge:tools/melee_weapons` for `EquipmentCondition::isMeleeWeapon` check, and `forge:tools/diggers` for `EquipmentCondition::isTool` check, making mods easier to integrate with PST for custom weapon types and custom tool types.